### PR TITLE
d2のインストールコマンドを追加

### DIFF
--- a/.github/workflows/text2Diagram.yml
+++ b/.github/workflows/text2Diagram.yml
@@ -1,0 +1,19 @@
+name: text2Diagram
+run-name: Diagram is made by ${{ github.actor }}
+
+on: 
+  push:
+    branches:
+      - main
+
+jobs: 
+  build_d2:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: install d2
+        run: curl -fsSL https://d2lang.com/install.sh | sh -s -- --dry-run
+        


### PR DESCRIPTION
ワークフローファイルがデフォルトブランチ上に無い場合、Actionsでワークフローを実行できない様なので、一度マージをお願いします。