### PR TITLE
redocly bundleの処理を修正

### DIFF
--- a/packages/backend/Makefile
+++ b/packages/backend/Makefile
@@ -26,7 +26,6 @@ codegen-from-oapi:
 	$(GOBIN)/oapi-codegen -generate server -package openapi ../shared/openapi/tmp/internalapi/openapi.yaml > app/controllers/internalapi/v1/openapi/internalapi_server.gen.go
 	$(GOBIN)/oapi-codegen -generate types -package openapi ../shared/openapi/tmp/internalapi/openapi.yaml > app/controllers/internalapi/v1/openapi/internalapi_types.gen.go
 	$(GOBIN)/oapi-codegen -generate spec -package openapi ../shared/openapi/tmp/internalapi/openapi.yaml > app/controllers/internalapi/v1/openapi/internalapi_spec.gen.go
-	
 	rm -r ../shared/openapi/tmp
 
 lint:

--- a/packages/backend/Makefile
+++ b/packages/backend/Makefile
@@ -22,10 +22,11 @@ generate-code-from-db:
 
 codegen-from-oapi:
 	mkdir ../shared/openapi/tmp
-	docker-compose up redocly
+	docker compose up redocly
 	$(GOBIN)/oapi-codegen -generate server -package openapi ../shared/openapi/tmp/internalapi/openapi.yaml > app/controllers/internalapi/v1/openapi/internalapi_server.gen.go
 	$(GOBIN)/oapi-codegen -generate types -package openapi ../shared/openapi/tmp/internalapi/openapi.yaml > app/controllers/internalapi/v1/openapi/internalapi_types.gen.go
 	$(GOBIN)/oapi-codegen -generate spec -package openapi ../shared/openapi/tmp/internalapi/openapi.yaml > app/controllers/internalapi/v1/openapi/internalapi_spec.gen.go
+	
 	rm -r ../shared/openapi/tmp
 
 lint:

--- a/packages/backend/docker-compose.yaml
+++ b/packages/backend/docker-compose.yaml
@@ -23,4 +23,6 @@ services:
       context: .
       dockerfile: ./docker/Dockerfile_redocly
     volumes:
-      - ../shared/openapi:/openapi
+      - ../shared/openapi/externalapi:/openapi/externalapi
+      - ../shared/openapi/internalapi:/openapi/internalapi
+      - ../shared/openapi/tmp:/openapi/tmp

--- a/packages/backend/docker/Dockerfile_redocly
+++ b/packages/backend/docker/Dockerfile_redocly
@@ -2,9 +2,7 @@ FROM node:alpine
 
 RUN npm install -g @redocly/cli
 
-WORKDIR /openapi/tmp
-RUN mkdir internalapi
-RUN mkdir externalapi
+COPY /docker/scripts/redocly_bundle.sh /openapi/scripts/redocly_bundle.sh
+RUN chmod +x /openapi/scripts/redocly_bundle.sh
 
-CMD ["redocly", "bundle", "/openapi/internalapi/openapi.yaml", "-o", "/openapi/tmp/internalapi/openapi.yaml"]
-CMD ["redocly", "bundle", "/openapi/externalapi/openapi.yaml", "-o", "/openapi/tmp/externalapi/openapi.yaml"]
+CMD ["/openapi/scripts/redocly_bundle.sh"]

--- a/packages/backend/docker/scripts/redocly_bundle.sh
+++ b/packages/backend/docker/scripts/redocly_bundle.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+redocly bundle /openapi/internalapi/openapi.yaml -o /openapi/tmp/internalapi/openapi.yaml
+redocly bundle /openapi/externalapi/openapi.yaml -o /openapi/tmp/externalapi/openapi.yaml

--- a/packages/backend/docker/scripts/redocly_bundle.sh
+++ b/packages/backend/docker/scripts/redocly_bundle.sh
@@ -2,3 +2,5 @@
 
 redocly bundle /openapi/internalapi/openapi.yaml -o /openapi/tmp/internalapi/openapi.yaml
 redocly bundle /openapi/externalapi/openapi.yaml -o /openapi/tmp/externalapi/openapi.yaml
+
+chmod -R 777 /openapi/tmp/


### PR DESCRIPTION
# Issue

none
<!--

対応するissueを記載してください。
URLでも可ですが、issueのclose忘れ等を避けるためキーワードを利用した記載を推奨します。

https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

e.g.
Closes #10

-->

# Overview

Dockerfile_redoclyにおいて、CMDを二重に記載している箇所があり、正常に動作しない状態となっていました。
そのため、CMDにてシェルスクリプトを実行する形で複数コマンドが実行できるように修正しました。

<!--

対応背景、内容等を記載してください。

-->

# Operation Verification

`make codegen-from-oapi`を実行し、コード生成が正常に行われることを確認しました。

```
% make codegen-from-oapi                       
mkdir ../shared/openapi/tmp
docker-compose up redocly
WARN[0000] The "SOURCE_DIR" variable is not set. Defaulting to a blank string. 
[+] Building 0.0s (0/0)                                                                                                                  docker:desktop-linux
[+] Running 1/0
 ✔ Container backend-redocly-1  Created                                                                                                                  0.0s 
Attaching to backend-redocly-1
backend-redocly-1  | (node:8) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
backend-redocly-1  | (Use `node --trace-deprecation ...` to show where the warning was created)
backend-redocly-1  | bundling /openapi/internalapi/openapi.yaml...
backend-redocly-1  | 📦 Created a bundle for /openapi/internalapi/openapi.yaml at /openapi/tmp/internalapi/openapi.yaml 36ms.
backend-redocly-1  | (node:46) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
backend-redocly-1  | (Use `node --trace-deprecation ...` to show where the warning was created)
backend-redocly-1  | bundling /openapi/externalapi/openapi.yaml...
backend-redocly-1  | 📦 Created a bundle for /openapi/externalapi/openapi.yaml at /openapi/tmp/externalapi/openapi.yaml 20ms.
backend-redocly-1 exited with code 0
/Users/xxx/src/github.com/stlatica/stlatica/packages/backend/bin/oapi-codegen -generate server -package openapi ../shared/openapi/tmp/internalapi/openapi.yaml > app/controllers/internalapi/v1/openapi/internalapi_server.gen.go
/Users/xxx/src/github.com/stlatica/stlatica/packages/backend/bin/oapi-codegen -generate types -package openapi ../shared/openapi/tmp/internalapi/openapi.yaml > app/controllers/internalapi/v1/openapi/internalapi_types.gen.go
/Users/xxx/src/github.com/stlatica/stlatica/packages/backend/bin/oapi-codegen -generate spec -package openapi ../shared/openapi/tmp/internalapi/openapi.yaml > app/controllers/internalapi/v1/openapi/internalapi_spec.gen.go
rm -r ../shared/openapi/tmp
```
<!--

動作検証結果のログ等があれば記載してください。

-->

# Check List

- [x] セルフレビューをした(must)
- [ ] テストコードを記載した
- [x] 動作検証の結果を記載した
- [ ] 関連するドキュメントの更新をした
- [x] 適切なLabelを設定した(e.g. frontend, documentation)
- [x] 適切なProjectを設定した(e.g. Minimum Structure)

# Others

<!--

補足等あれば記載してください。

-->
