### PR TITLE
アイコンのトリミング機能（css調整前）

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -36,6 +36,7 @@
     "next": "14.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-easy-crop": "^5.0.5",
     "react-hook-form": "^7.49.2",
     "react-icons": "^4.12.0",
     "swr": "^2.2.4",

--- a/packages/frontend/pnpm-lock.yaml
+++ b/packages/frontend/pnpm-lock.yaml
@@ -32,6 +32,9 @@ dependencies:
   react-dom:
     specifier: 18.2.0
     version: 18.2.0(react@18.2.0)
+  react-easy-crop:
+    specifier: ^5.0.5
+    version: 5.0.5(react-dom@18.2.0)(react@18.2.0)
   react-hook-form:
     specifier: ^7.49.2
     version: 7.49.2(react@18.2.0)
@@ -6944,6 +6947,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /normalize-wheel@1.0.1:
+    resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
+    dev: false
+
   /npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
@@ -7780,6 +7787,18 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+
+  /react-easy-crop@5.0.5(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-GH7Jw3898ytSaN4i4Oxi7j3BKzapZ2pVgnKIl+gFIUjA+NsDgdBSIpiBQUrPFIvHzSnPmz0kGCpX95X6NgsDzA==}
+    peerDependencies:
+      react: '>=16.4.0'
+      react-dom: '>=16.4.0'
+    dependencies:
+      normalize-wheel: 1.0.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tslib: 2.0.1
+    dev: false
 
   /react-frame-component@5.2.4(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-4xpZFcLNS6LCEYSlWgsUy81v7LjdgbvB0VHIq7sNSD25PK+e5YYCrdy5557ebGwNLKNLEpYVfAkT3pVzFLPb1g==}
@@ -8873,6 +8892,10 @@ packages:
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
+
+  /tslib@2.0.1:
+    resolution: {integrity: sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==}
+    dev: false
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}

--- a/packages/frontend/src/app/test/CropIcon/getCroppedImg.ts
+++ b/packages/frontend/src/app/test/CropIcon/getCroppedImg.ts
@@ -1,0 +1,59 @@
+import { Area } from "react-easy-crop";
+
+// 参考
+// https://codesandbox.io/p/sandbox/suspicious-http-rqfrgb?file=%2Fsrc%2FgetCroppedImg.ts%3A1%2C1-60%2C1&from-embed=
+
+/**
+ * urlをもとにimage要素を作成
+ */
+export const createImage = (url: string): Promise<HTMLImageElement> => {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener("load", () => {
+      resolve(image);
+    });
+    image.addEventListener("error", (error) => {
+      reject(error);
+    });
+    // CodeSandboxでCORSエラーを回避するために必要
+    image.setAttribute("crossOrigin", "anonymous");
+    image.src = url;
+  });
+};
+
+/**
+ * 画像トリミングを行い新たな画像urlを作成
+ */
+export default async function getCroppedImg(imageSrc: string, pixelCrop: Area): Promise<string> {
+  const image = await createImage(imageSrc);
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+
+  if (!ctx) {
+    return "";
+  }
+
+  // canvasサイズを設定
+  canvas.width = image.width;
+  canvas.height = image.height;
+
+  // canvas上に画像を描画
+  ctx.drawImage(image, 0, 0);
+
+  // トリミング後の画像を抽出
+  const data = ctx.getImageData(pixelCrop.x, pixelCrop.y, pixelCrop.width, pixelCrop.height);
+
+  // canvasのサイズ指定(切り取り後の画像サイズに更新)
+  canvas.width = pixelCrop.width;
+  canvas.height = pixelCrop.height;
+
+  // 抽出した画像データをcanvasの左隅に貼り付け
+  ctx.putImageData(data, 0, 0);
+
+  // canvasを画像に変換
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((file) => {
+      if (file !== null) resolve(URL.createObjectURL(file));
+    }, "image/jpeg");
+  });
+}

--- a/packages/frontend/src/app/test/CropIcon/page.tsx
+++ b/packages/frontend/src/app/test/CropIcon/page.tsx
@@ -1,0 +1,110 @@
+"use client";
+import { Button } from "@mantine/core";
+import React, { useState, useCallback } from "react";
+import Cropper, { Area } from "react-easy-crop";
+
+import getCroppedImg from "./getCroppedImg";
+
+// 参考
+// ファイルのアップロード：https://zenn.dev/yuyan/articles/f35da08770a135
+// Cropper：https://codesandbox.io/p/sandbox/suspicious-http-rqfrgb?file=%2Fsrc%2FApp.tsx%3A163%2C9&from-embed=
+export default function Home() {
+  const [base64Image, setBase64Image] = useState<string>(""); // 画像を一枚だけ保持するためのstate
+
+  const handleInputFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files ? e.target.files[0] : null; // 単一のファイルを選択
+    if (!file) {
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const result = reader.result;
+      if (typeof result === "string") {
+        setBase64Image(result); // 前回の画像を上書きして新しい画像をセット
+      }
+    };
+    reader.readAsDataURL(file); // 画像ファイルをbase64形式で読み込む
+  };
+
+  /** 画像の拡大縮小倍率 */
+  const [zoom, setZoom] = useState<number>(1);
+
+  /** 切り取る領域の情報 */
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  /** 切り取る領域の情報 */
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area>();
+
+  /** 切り取ったあとの画像URL */
+  const [croppedImgSrc, setCroppedImgSrc] = useState("");
+
+  /**
+   * 切り取り完了後、切り取り領域の情報をセット
+   */
+  const onCropComplete = useCallback((croppedArea: Area, croppedAreaPixels: Area) => {
+    setCroppedAreaPixels(croppedAreaPixels);
+  }, []);
+
+  /**
+   * 切り取り後の画像を生成し画面に表示
+   */
+  const showCroppedImage = useCallback(async () => {
+    if (!croppedAreaPixels) return;
+    try {
+      const croppedImage = await getCroppedImg(base64Image, croppedAreaPixels);
+      setCroppedImgSrc(croppedImage);
+    } catch (e) {
+      console.error(e);
+    }
+  }, [croppedAreaPixels, base64Image]);
+
+  return (
+    <div>
+      <div className="relative h-[300px] w-[300px]">
+        <Cropper
+          crop={crop}
+          cropShape="round"
+          cropSize={{ width: 300, height: 300 }}
+          image={base64Image}
+          maxZoom={5}
+          minZoom={1}
+          onCropChange={setCrop}
+          onCropComplete={onCropComplete}
+          onZoomChange={setZoom}
+          showGrid={false}
+          zoom={zoom}
+        />
+      </div>
+      <div>
+        <input
+          aria-labelledby="Zoom"
+          max={5}
+          min={1}
+          onChange={(e) => {
+            setZoom(e.target.valueAsNumber);
+          }}
+          step={0.1}
+          type="range"
+          value={zoom}
+        />
+      </div>
+      <div>
+        <input accept="image/jpeg, image/png" onChange={handleInputFile} type="file" />
+        <Button
+          onClick={() => {
+            showCroppedImage();
+          }}
+        >
+          OK
+        </Button>
+      </div>
+      <div>
+        {croppedImgSrc ? (
+          <img alt="Cropped" className="h-[300px] w-[300px]" src={croppedImgSrc} />
+        ) : (
+          <div>The cropped image is displayed here</div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# Issue

Closes #124

画像のトリミング機能

# Overview

プロフィール画面のアイコン設定箇所で画像をトリミングする機能を作成しました。
ひとまず画像のアップロードと切り抜き機能だけ実装したので確認をお願いします。

![image](https://github.com/stlatica/stlatica/assets/79183832/ee672bb0-e57f-4c9a-9c5c-91d25989c1f3)


# Operation Verification

<!--

動作検証結果のログ等があれば記載してください。

-->

# Check List

- [x] セルフレビューをした(must)
- [ ] テストコードを記載した
- [x] 動作検証の結果を記載した
- [ ] 関連するドキュメントの更新をした
- [x] 適切なLabelを設定した(e.g. frontend, documentation)
- [x] 適切なProjectを設定した(e.g. Minimum Structure)

# Others

<!--

補足等あれば記載してください。

-->
