### PR TITLE
Fix lint in openapi.yaml

### DIFF
--- a/packages/shared/openapi/internalapi/openapi.yaml
+++ b/packages/shared/openapi/internalapi/openapi.yaml
@@ -3,13 +3,16 @@ info:
   title: stlatica_internal_api
   version: 0.1.0
   description: stlatica internal api
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
 servers:
   - url: http://localhost:4010
     description: prism mock server
 paths:
   /internal/v1/users/{user_id}:
     $ref: './paths/users.yaml#/users_{user_id}'
-  /internal/v1/users/:
+  /internal/v1/users:
     $ref: './paths/users.yaml#/users'
   /internal/v1/plats/{plat_id}:
     $ref: './paths/plats.yaml#/plat_{plat_id}'
@@ -23,13 +26,11 @@ paths:
     $ref: './paths/timelines.yaml#/timelines'
   /internal/v1/images/{image_id}:
     $ref: './paths/images.yaml#/images_{image_id}'
+security:
+  - Bearer: []
 components:
-  schemas:
-    SampleUser:
-      type: object
-      required:
-        - username
-      properties:
-        username:
-          type: string
-          example: 'sample_user'
+  securitySchemes:
+    Bearer:
+      type: http
+      scheme: bearer
+      description: access token

--- a/packages/shared/openapi/internalapi/paths/plats.yaml
+++ b/packages/shared/openapi/internalapi/paths/plats.yaml
@@ -170,9 +170,10 @@ plats:
 favorite_{plat_id}:
   post:
     summary: Add "favorite" to a specific plat by ID.
+    operationId: postFavorite
     parameters:
       - $ref: '../parameters/plat_id.yaml#/plat_id'
-    response:
+    responses:
       200:
         description: OK
       400:
@@ -219,9 +220,10 @@ favorite_{plat_id}:
               $ref: '../schemas/ErrorResponse.yaml#/ErrorResponse'
   delete:
     summary: Delete "favorite" to a specific plat by ID.
+    operationId: deleteFavorite
     parameters:
       - $ref: '../parameters/plat_id.yaml#/plat_id'
-    response:
+    responses:
       204:
         description: No content.
       400:

--- a/packages/shared/openapi/internalapi/paths/users.yaml
+++ b/packages/shared/openapi/internalapi/paths/users.yaml
@@ -134,7 +134,7 @@ users:
         content:
           application/json:
             schema:
-              $ref: '../schemas/UserID.yaml'
+              $ref: '../schemas/UserID.yaml#/UserID'
       400:
         description: |
           bad request \
@@ -197,7 +197,6 @@ users:
     description: Get users.
     operationId: getUsers
     parameters:
-      - $ref: '../parameters/user_id.yaml#/user_id'
       - in: query
         name: user_name
         schema:
@@ -208,10 +207,10 @@ users:
         description: success
         content:
           application/json:
-            type: array
-            items:
-              schema:
-                - $ref: '../schemas/User.yaml' 
+            schema:
+              type: array
+              items:
+                $ref: '../schemas/User.yaml#/User'
       400:
         description: |
           bad request \


### PR DESCRIPTION
# Issue

none
<!--

対応するissueを記載してください。
URLでも可ですが、issueのclose忘れ等を避けるためキーワードを利用した記載を推奨します。

https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

e.g.
Closes #10

-->

# Overview

redocly lintに適合するようにopenapi定義を修正します。
<!--

対応背景、内容等を記載してください。

-->

# Operation Verification

`openapi/lint` branchにて`make internal-lint`を実行しlint errorが出なくなったことを確認しました。
warningが1つ出たままとなっていますが、別PRにてignore fileに登録する対応を行う予定です。

before
```
~/src/.../shared/openapi  openapi/lint % make internal-lint
docker compose up -d redocly
[+] Building 0.0s (0/0)                                                                                                                  docker:desktop-linux
[+] Running 1/0
 ✔ Container stlatica_redocly  Running                                                                                                                   0.0s 
docker compose exec -it redocly redocly lint internalapi/openapi.yaml
No configurations were provided -- using built in recommended configuration by default.

...

internalapi.yaml: validated in 167ms

❌ Validation failed with 21 errors and 5 warnings.
run `redocly lint --generate-ignore-file` to add all problems to the ignore file.

make: *** [internal-lint] Error 1
```

after
```
~/src/.../shared/openapi openapi/lint [*] % make internal-lint
docker compose up -d redocly
[+] Building 0.0s (0/0)                                                                                                                  docker:desktop-linux
[+] Running 1/0
 ✔ Container stlatica_redocly  Running                                                                                                                   0.0s 
docker compose exec -it redocly redocly lint internalapi/openapi.yaml
No configurations were provided -- using built in recommended configuration by default.

validating internalapi.yaml...
[1] internalapi/openapi.yaml:10:10 at #/servers/0/url

Server `url` should not point to example.com or localhost.

 8 |     url: https://opensource.org/licenses/MIT
 9 | servers:
10 |   - url: http://localhost:4010
11 |     description: prism mock server
12 | paths:

Warning was generated by the no-server-example.com rule.


internalapi.yaml: validated in 43ms

Woohoo! Your API description is valid. 🎉
You have 1 warning.

```

<!--

動作検証結果のログ等があれば記載してください。

-->

# Check List

- [x] セルフレビューをした(must)
- [ ] テストコードを記載した
- [x] 動作検証の結果を記載した
- [ ] 関連するドキュメントの更新をした
- [x] 適切なLabelを設定した(e.g. frontend, documentation)
- [x] 適切なProjectを設定した(e.g. Minimum Structure)

# Others

<!--

補足等あれば記載してください。

-->
