### PR TITLE
makefile の docker compose を docker-compose に置換

### DIFF
--- a/packages/frontend/Makefile
+++ b/packages/frontend/Makefile
@@ -1,25 +1,25 @@
-DOCKER_VRT_RUN := docker compose run --rm --service-ports playwright_vrt /bin/sh -c
+DOCKER_VRT_RUN := docker-compose run --rm --service-ports playwright_vrt /bin/sh -c
 
 quick-dev: docker/build_node node_modules
-	docker compose run --rm --service-ports front_dev /bin/sh -c "pnpm dev"
+	docker-compose run --rm --service-ports front_dev /bin/sh -c "pnpm dev"
 # --service-ports でcomposeのポートを使える
 
 
 dev: dev/up
-	docker compose exec -it front_dev bash
+	docker-compose exec -it front_dev bash
 
 ladle: dev/up
-	docker compose exec -it front_dev pnpm ladle:dev
+	docker-compose exec -it front_dev pnpm ladle:dev
 
 dev/up: docker/build_node node_modules
-	docker compose up --build -d front_dev
+	docker-compose up --build -d front_dev
 
 # TODO: 権限のその場しのぎ対応 https://github.com/stlatica/stlatica/issues/354
 dev/permission:
 	sudo chmod 777 -R .
 
 down:
-	docker compose down
+	docker-compose down
 
 
 docker/clear-cache:
@@ -27,7 +27,7 @@ docker/clear-cache:
 	rm docker/build_playwright
 
 docker/stop: 
-	docker compose down --remove-orphans
+	docker-compose down --remove-orphans
 
 vrt: docker/build_playwright
 	${DOCKER_VRT_RUN} "pnpm install --frozen-lockfile --force && pnpm vrt"


### PR DESCRIPTION
# Issue

Closes #387 

# Overview

@para7 

`make vrt` が実行できなかったので makefile の docker compose の間にハイフンを追加したところ実行可能になりました。

# Operation Verification

<!--

動作検証結果のログ等があれば記載してください。

-->

# Check List

- [x] セルフレビューをした(must)
- [ ] テストコードを記載した
- [ ] 動作検証の結果を記載した
- [ ] 関連するドキュメントの更新をした
- [ ] 適切なLabelを設定した(e.g. frontend, documentation)
- [ ] 適切なProjectを設定した(e.g. Minimum Structure)

# Others

<!--

補足等あれば記載してください。

-->
