### PR TITLE
external apiのopenapi定義をlintに合わせて修正

### DIFF
--- a/packages/shared/openapi/externalapi/openapi.yaml
+++ b/packages/shared/openapi/externalapi/openapi.yaml
@@ -3,6 +3,12 @@ info:
   title: stlatica_external_api
   version: 0.1.0
   description: stlatica external api
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+servers:
+  - url: http://localhost:4010
+    description: prism mock server
 paths:
   /external/v1/sample_users/{sample_user_id}:
     get:
@@ -80,7 +86,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /.well-known/webfinger?resource=acct:{actor_id}@{server_domain}:
+  /.well-known/webfinger:
     get:
       operationId: getWebfinger
       tags:
@@ -88,8 +94,18 @@ paths:
       summary: get Webfinger
       description: get Webfinger
       parameters:
-        - $ref: '#/components/parameters/actor_id'
-        - $ref: '#/components/parameters/server_domain'
+        - in: query
+          required: true
+          name: resource
+          description: |
+            resource
+            
+            format: acct:{actor_id}@{server_domain}
+              - actor_id: actor_id e.g.) 'example_actor'
+              - server_domain: server_domain e.g.) 'stlatica.hoge'
+          schema:
+            type: string
+          example: 'acct:{actor_id}@{server_domain}'
       responses:
         200:
           description: success
@@ -97,20 +113,6 @@ paths:
             application/jrd+json:
               schema:
                 $ref: '#/components/schemas/Webfinger'
-              example:
-                subject: 'acct:example_actor@stlatica.hoge'
-                aliases:
-                  - 'https://stlatica.hoge/@example_actor'
-                  - 'https://stlatica.hoge/users/example_actor'
-                links:
-                  - rel: 'http://webfinger.net/rel/profile-page'
-                    type: 'text/html'
-                    href: 'https://stlatica.hoge/@example_actor'
-                  - rel: 'self'
-                    type: 'application/activity+json'
-                    href: 'https://stlatica.hoge/users/example_actor'
-                  - rel: 'http://ostatus.org/schema/1.0/subscribe'
-                    template: 'https://stlatica.hoge/authorize_interaction?uri={uri}'
         400:
           description: |
             bad request \
@@ -235,14 +237,6 @@ components:
       schema:
         type: string
       example: 'actor_id'
-    server_domain:
-      in: path
-      required: true
-      name: domain_name
-      description: server domain
-      schema:
-        type: string
-      example: 'stlatica.hoge'
   schemas:
     SampleUser:
       type: object
@@ -334,13 +328,42 @@ components:
       type: object
       description: Webfinger
       required:
-        - 'actor_id'
-        - 'server_domain'
+        - subject
+        - aliases
+        - links
       properties:
-        actor_id:
-          $ref: '#/components/parameters/actor_id'
-        server_domain:
-          $ref: '#/components/parameters/server_domain'
+        subject:
+          type: string
+          example: 'acct:example_actor@stlatica.hoge'
+        aliases:
+          type: string
+          example:
+            - 'https://stlatica.hoge/@example_actor'
+            - 'https://stlatica.hoge/users/example_actor'
+        links:
+          type: array
+          items:
+            type: object
+            properties:
+              rel:
+                type: string
+                example:
+                  - 'http://webfinger.net/rel/profile-page'
+                  - 'self'
+                  - 'http://ostatus.org/schema/1.0/subscribe'
+              type:
+                type: string
+                example:
+                  - 'text/html'
+                  - 'application/activity+json'
+              href:
+                type: string
+                example:
+                  - 'https://stlatica.hoge/@example_actor'
+                  - 'https://stlatica.hoge/users/example_actor'
+              template:
+                type: string
+                example: 'https://stlatica.hoge/authorize_interaction?uri={uri}'
     JSONLDContexts:
       description: |
         以下のうちのいずれかを使用する
@@ -455,3 +478,4 @@ components:
         message:
           type: string
           example: 'error message'
+security: []


### PR DESCRIPTION
# Issue

Closes #381 

<!--

対応するissueを記載してください。
URLでも可ですが、issueのclose忘れ等を避けるためキーワードを利用した記載を推奨します。

https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

e.g.
Closes #10

-->

# Overview

redocly lintに適合するようにopenapi定義を修正します。

<!--

対応背景、内容等を記載してください。

-->

# Operation Verification

<!--

動作検証結果のログ等があれば記載してください。

-->

openapi/lint branchにてmake external-lintを実行しlint errorが出なくなったことを確認しました。
warningが5つほど出たままとなっていますが、別PRにてignore fileに登録する対応を行う予定です。

before
```
~/src/.../shared/openapi  openapi/ci [*] % make external-lint
docker compose up -d redocly
[+] Building 0.0s (0/0)                                                                                                                                                                docker:desktop-linux
[+] Running 1/0
 ✔ Container stlatica_redocly  Running                                                                                                                                                                 0.0s 
docker compose exec -it redocly redocly lint externalapi/openapi.yaml

...

externalapi.yaml: validated in 55ms

❌ Validation failed with 18 errors and 6 warnings.
run `redocly lint --generate-ignore-file` to add all problems to the ignore file.

make: *** [external-lint] Error 1
```

after
```
~/src/.../shared/openapi  openapi/ci [*] % make external-lint                      
docker compose up -d redocly
[+] Building 0.0s (0/0)                                                                                                                                                                docker:desktop-linux
[+] Running 1/0
 ✔ Container stlatica_redocly  Running                                                                                                                                                                 0.0s 
docker compose exec -it redocly redocly lint externalapi/openapi.yaml

...

externalapi.yaml: validated in 40ms

Woohoo! Your API description is valid. 🎉
You have 5 warnings.
```

# Check List

- [x] セルフレビューをした(must)
- [ ] テストコードを記載した
- [x] 動作検証の結果を記載した
- [ ] 関連するドキュメントの更新をした
- [x] 適切なLabelを設定した(e.g. frontend, documentation)
- [x] 適切なProjectを設定した(e.g. Minimum Structure)

# Others

<!--

補足等あれば記載してください。

-->
