### PR TITLE
error handlerを追加

### DIFF
--- a/packages/backend/app/cmd/internalapi/main.go
+++ b/packages/backend/app/cmd/internalapi/main.go
@@ -44,7 +44,7 @@ func main() {
 		UserUseCase: userusecase.NewUserUseCase(appLogger, userFactory, userDAO),
 		PlatUseCase: platusecase.NewPlatUseCase(appLogger, platFactory, platDAO),
 	}
-	v1controllers.RegisterHandlers(*initContent, e)
+	v1controllers.RegisterHandlers(*initContent, e, appLogger)
 
 	err = e.Start(fmt.Sprintf(`:%s`, os.Getenv("STLATICA_SERVER_PORT")))
 	if err != nil {

--- a/packages/backend/app/controllers/internalapi/v1/error_handler.go
+++ b/packages/backend/app/controllers/internalapi/v1/error_handler.go
@@ -1,0 +1,17 @@
+package v1
+
+import (
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stlatica/stlatica/packages/backend/app/logger"
+)
+
+// NewErrorHandler returns a new HTTPErrorHandler.
+func NewErrorHandler(e *echo.Echo, appLogger *logger.AppLogger) echo.HTTPErrorHandler {
+	return func(err error, ectx echo.Context) {
+		// TODO: trace IDとuser IDをcontextから取得してログに出力する https://github.com/stlatica/stlatica/issues/403
+		appLogger.Error(ectx.Request().Context(), err.Error(), "", time.Now(), "")
+		e.DefaultHTTPErrorHandler(err, ectx)
+	}
+}

--- a/packages/backend/app/controllers/internalapi/v1/handler.go
+++ b/packages/backend/app/controllers/internalapi/v1/handler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/stlatica/stlatica/packages/backend/app/controllers/internalapi/v1/openapi"
+	"github.com/stlatica/stlatica/packages/backend/app/logger"
 	"github.com/stlatica/stlatica/packages/backend/app/usecases/plats"
 	"github.com/stlatica/stlatica/packages/backend/app/usecases/users"
 )
@@ -26,9 +27,11 @@ func newHandler(initContent ControllerInitContents) openapi.ServerInterface {
 }
 
 // RegisterHandlers adds each server route to the EchoRouter.
-func RegisterHandlers(initContent ControllerInitContents, server *echo.Echo) {
+func RegisterHandlers(initContent ControllerInitContents, server *echo.Echo, appLogger *logger.AppLogger) {
 	handler := newHandler(initContent)
 	openapi.RegisterHandlers(server, handler)
+
+	server.HTTPErrorHandler = NewErrorHandler(server, appLogger)
 }
 
 // GetUser is the handler for GET /users/{user_id}, ServerInterface implementation.

--- a/packages/backend/app/pkg/logger/zap.go
+++ b/packages/backend/app/pkg/logger/zap.go
@@ -6,13 +6,17 @@ import (
 	"go.uber.org/zap"
 )
 
+const callerSkipCount = 2
+
 type zapLogger struct {
 	orgLogger *zap.Logger
 }
 
 // NewZapLogger creates new instance that implements Logger interface
 func NewZapLogger() Logger {
-	logger, err := zap.NewDevelopment(zap.AddCallerSkip(1))
+	config := zap.NewDevelopmentConfig()
+	config.DisableStacktrace = true
+	logger, err := config.Build(zap.AddCallerSkip(callerSkipCount))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# Issue

Closes #178
<!--

対応するissueを記載してください。
URLでも可ですが、issueのclose忘れ等を避けるためキーワードを利用した記載を推奨します。

https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

e.g.
Closes #10

-->

# Overview

log出力だけ行うerror handlerを追加します。
status codeの変更などは`DefaultHTTPErrorHandler`に任せてしまっている状態ですが、必要になったタイミングで随時追加していく予定です。

<!--

対応背景、内容等を記載してください。

-->

# Operation Verification

internalapiをerrorが発生する条件で呼び出した場合にerror logが出力されることを確認しました。

```
~/src/.../packages/backend add-error-handler % make start-local-internalapi
GO_ENV=local go run app/cmd/internalapi/main.go
2024-04-21T22:21:31.732+0900    ERROR   v1/error_handler.go:14  sql: no rows in result set
```
<!--

動作検証結果のログ等があれば記載してください。

-->

# Check List

- [x] セルフレビューをした(must)
- [ ] テストコードを記載した
- [x] 動作検証の結果を記載した
- [ ] 関連するドキュメントの更新をした
- [x] 適切なLabelを設定した(e.g. frontend, documentation)
- [x] 適切なProjectを設定した(e.g. Minimum Structure)

# Others

<!--

補足等あれば記載してください。

-->
