### PR TITLE
READMEに技術スタック系バッジ追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <!-- ステータス系 -->
 ![Github Created At](https://img.shields.io/github/created-at/stlatica/stlatica?style=plastic)
-[![build](https://github.com/stlatica/stlatica/actions/workflows/actions.yml/badge.svg?branch=main)](https://github.com/stlatica/stlatica/actions/workflows/actions.yml)
 ![GitHub repo size](https://img.shields.io/github/repo-size/stlatica/stlatica?style=plastic)
+[![build](https://github.com/stlatica/stlatica/actions/workflows/actions.yml/badge.svg?branch=main)](https://github.com/stlatica/stlatica/actions/workflows/actions.yml)
 
 <!-- アクティビティ系 -->
 [![GitHub commit activity(week)](https://img.shields.io/github/commit-activity/w/stlatica/stlatica)](https://github.com/stlatica/stlatica/pulse)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
-# Stlatica ![Github Created At](https://img.shields.io/github/created-at/stlatica/stlatica) [![build](https://github.com/stlatica/stlatica/actions/workflows/actions.yml/badge.svg?branch=main)](https://github.com/stlatica/stlatica/actions/workflows/actions.yml) ![GitHub repo size](https://img.shields.io/github/repo-size/stlatica/stlatica)
+# Stlatica 
 
-[![GitHub commit activity(week)](https://img.shields.io/github/commit-activity/w/stlatica/stlatica)](https://github.com/stlatica/stlatica/pulse) [![GitHub commit activity(month)](https://img.shields.io/github/commit-activity/m/stlatica/stlatica)](https://github.com/stlatica/stlatica/pulse/monthly) [![GitHub commit activity(year)](https://img.shields.io/github/commit-activity/y/stlatica/stlatica)](https://github.com/stlatica/stlatica/graphs/commit-activity) [![GitHub Issues or Pull Requests by label](https://img.shields.io/github/issues/stlatica/stlatica/bug)](https://github.com/stlatica/stlatica/labels/bug)
+<!-- ステータス系 -->
+![Github Created At](https://img.shields.io/github/created-at/stlatica/stlatica?style=plastic)
+[![build](https://github.com/stlatica/stlatica/actions/workflows/actions.yml/badge.svg?branch=main)](https://github.com/stlatica/stlatica/actions/workflows/actions.yml?style=plastic)
+![GitHub repo size](https://img.shields.io/github/repo-size/stlatica/stlatica?style=plastic)
+
+<!-- アクティビティ系 -->
+[![GitHub commit activity(week)](https://img.shields.io/github/commit-activity/w/stlatica/stlatica?style=plastic)](https://github.com/stlatica/stlatica/pulse)
+[![GitHub commit activity(month)](https://img.shields.io/github/commit-activity/m/stlatica/stlatica?style=plastic)](https://github.com/stlatica/stlatica/pulse/monthly)
+[![GitHub commit activity(year)](https://img.shields.io/github/commit-activity/y/stlatica/stlatica?style=plastic)](https://github.com/stlatica/stlatica/graphs/commit-activity)
+[![GitHub Issues or Pull Requests by label](https://img.shields.io/github/issues/stlatica/stlatica/bug?style=plastic)](https://github.com/stlatica/stlatica/labels/bug)
+
+<!-- 技術スタック系 -->
+<!-- https://ileriayo.github.io/markdown-badges/ -->
+![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white)
+![Go](https://img.shields.io/badge/go-%2300ADD8.svg?style=for-the-badge&logo=go&logoColor=white)
+![MySQL](https://img.shields.io/badge/mysql-4479A1.svg?style=for-the-badge&logo=mysql&logoColor=white)
+![PNPM](https://img.shields.io/badge/pnpm-%234a4a4a.svg?style=for-the-badge&logo=pnpm&logoColor=f69220)
+![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)
+![Remix](https://img.shields.io/badge/remix-%23000.svg?style=for-the-badge&logo=remix&logoColor=white)
+![Mantine](https://img.shields.io/badge/Mantine-ffffff?style=for-the-badge&logo=Mantine&logoColor=339af0)
+
 
 SNS to support community activities
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 <!-- ステータス系 -->
 ![Github Created At](https://img.shields.io/github/created-at/stlatica/stlatica?style=plastic)
-[![build](https://github.com/stlatica/stlatica/actions/workflows/actions.yml/badge.svg?branch=main)](https://github.com/stlatica/stlatica/actions/workflows/actions.yml?style=plastic)
+[![build](https://github.com/stlatica/stlatica/actions/workflows/actions.yml/badge.svg?branch=main)](https://github.com/stlatica/stlatica/actions/workflows/actions.yml)
 ![GitHub repo size](https://img.shields.io/github/repo-size/stlatica/stlatica?style=plastic)
 
 <!-- アクティビティ系 -->
-[![GitHub commit activity(week)](https://img.shields.io/github/commit-activity/w/stlatica/stlatica?style=plastic)](https://github.com/stlatica/stlatica/pulse)
-[![GitHub commit activity(month)](https://img.shields.io/github/commit-activity/m/stlatica/stlatica?style=plastic)](https://github.com/stlatica/stlatica/pulse/monthly)
-[![GitHub commit activity(year)](https://img.shields.io/github/commit-activity/y/stlatica/stlatica?style=plastic)](https://github.com/stlatica/stlatica/graphs/commit-activity)
-[![GitHub Issues or Pull Requests by label](https://img.shields.io/github/issues/stlatica/stlatica/bug?style=plastic)](https://github.com/stlatica/stlatica/labels/bug)
+[![GitHub commit activity(week)](https://img.shields.io/github/commit-activity/w/stlatica/stlatica)](https://github.com/stlatica/stlatica/pulse)
+[![GitHub commit activity(month)](https://img.shields.io/github/commit-activity/m/stlatica/stlatica)](https://github.com/stlatica/stlatica/pulse/monthly)
+[![GitHub commit activity(year)](https://img.shields.io/github/commit-activity/y/stlatica/stlatica)](https://github.com/stlatica/stlatica/graphs/commit-activity)
+[![GitHub Issues or Pull Requests by label](https://img.shields.io/github/issues/stlatica/stlatica/bug)](https://github.com/stlatica/stlatica/labels/bug)
 
 <!-- 技術スタック系 -->
 <!-- https://ileriayo.github.io/markdown-badges/ -->


### PR DESCRIPTION
# Issue

<!--

対応するissueを記載してください。
URLでも可ですが、issueのclose忘れ等を避けるためキーワードを利用した記載を推奨します。

https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

e.g.
Closes #10

-->

# Overview

<!--

対応背景、内容等を記載してください。

-->

- ~~前つけたバッジを、plasticスタイルに変更しました~~ リンク先が設定されていない飾りのみ plastic に変更しました
- 一目見て技術スタックがわかるバッジを追加してみました https://ileriayo.github.io/markdown-badges/


# Operation Verification

プレビュー 
https://github.com/stlatica/stlatica/tree/add-lang-badges

<!--

動作検証結果のログ等があれば記載してください。

-->

# Check List

- [x] セルフレビューをした(must)
- [ ] テストコードを記載した
- [ ] 動作検証の結果を記載した
- [ ] 関連するドキュメントの更新をした
- [x] 適切なLabelを設定した(e.g. frontend, documentation)
- [ ] 適切なProjectを設定した(e.g. Minimum Structure)



# Others

<!--

補足等あれば記載してください。

-->

READMEがかっこいいと士気が高まる効果が期待できます[要出典]
