### PR TITLE
ladle hmr 対応

### DIFF
--- a/packages/frontend/Makefile
+++ b/packages/frontend/Makefile
@@ -11,7 +11,10 @@ bash: util/build ## run bash (for package install etc.) ##
 	docker compose run --rm -it front_dev bash
 
 ladle: util/build remix/node_modules ## run ladle (storybook server)
-	docker compose run --rm -p 127.0.0.1:61000:61000  front_dev bash -c "pnpm run ladle dev"
+	docker compose run --rm front_dev_ladle bash -c "pnpm run ladle dev"
+
+ladle-no-hmr: util/build remix/node_modules ## ladle for docker windows / mac
+	docker compose run --rm -p 127.0.0.1:61000:61000 -p 127.0.0.1:24678:24678 front_dev bash -c "pnpm run ladle dev"
 
 lint: util/build remix/node_modules ## lint & format
 	docker compose run --rm front_dev bash -c "pnpm run lint"

--- a/packages/frontend/docker-compose.yaml
+++ b/packages/frontend/docker-compose.yaml
@@ -21,6 +21,24 @@ services:
       - "127.0.0.1:61000:61000"
     tty: true
 
+  # ladleのHMRが機能していないのでnet: host で対応する
+  # https://github.com/tajo/ladle/issues/557
+  front_dev_ladle:
+    build:
+      context: docker
+      dockerfile: Dockerfile.node
+      target: dev
+    working_dir: /app/packages/frontend/remix
+    volumes:
+      - type: bind
+        source: ./remix
+        target: /app/packages/frontend/remix
+      - type: bind
+        source: ../shared/
+        target: /app/packages/shared
+    network_mode: host
+    tty: true
+
   playwright_vrt:
     build:
       context: docker


### PR DESCRIPTION
# Issue
<!--
対応するissueを記載してください。
URLでも可ですが、issueのclose忘れ等を避けるためキーワードを利用した記載を推奨します。
https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
e.g.) Closes #10
-->

# Overview
<!-- 対応背景、内容等を記載してください。 -->

make ladle のホットリロードが機能してなかったので修正しました。
本問題は ladle 側の不具合のため、仕方なく docker のネットワークモード側をいじって修正しました。

# Operation Verification
<!-- 動作検証結果のログ等があれば記載してください。 -->

1. make ladle
2. ブラウザで開く
3. 開発者モードでコンソールを開き、エラーが出ていないことを確認


# Check List

- [ ] セルフレビューをした(must)
- [ ] テストコードを記載した
- [ ] 動作検証の結果を記載した
- [ ] 関連するドキュメントの更新をした
- [ ] 適切なLabelを設定した(e.g. frontend, documentation)
- [ ] 適切なProjectを設定した(e.g. Minimum Structure)

# Others
<!-- 補足等あれば記載してください。 -->

docker networkのホストモードは linux でしか動作しないらしいので、古いコマンドも残してあります。