### PR TITLE
OpenAPIのDocker起動を修正

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -191,6 +191,6 @@ jobs:
       - name: build container image
         run: make docker-build
       - name: internal api lint
-        run: make internal-lint
+        run: make internal/lint
       - name: external api lint
-        run: make external-lint
+        run: make external/lint

--- a/packages/shared/openapi/.gitignore
+++ b/packages/shared/openapi/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 build
-openapi-bundled.yaml

--- a/packages/shared/openapi/Makefile
+++ b/packages/shared/openapi/Makefile
@@ -1,72 +1,37 @@
-DOCKER_RUN := docker compose exec -it redocly
+DOCKER_RUN := docker compose run -it redocly
 
-x: help
+.DEFAULT_GOAL := help
 
+internal/preview: docker-build ## API定義確認サーバーを起動します
+	docker compose run -it -p 127.0.0.1:8080:8080 redocly redocly preview-docs --host 0.0.0.0 internalapi/openapi.yaml -p 8080
+external/preview: docker-build ## API定義確認サーバーを起動します
+	docker compose run -it -p 127.0.0.1:8081:8081 redocly redocly preview-docs --host 0.0.0.0 externalapi/openapi.yaml -p 8081
 
-internal-preview: docker-up
-	${DOCKER_RUN} redocly preview-docs --host 0.0.0.0 internalapi/openapi.yaml -p 8080
-external-preview: docker-up
-	${DOCKER_RUN} redocly preview-docs --host 0.0.0.0 externalapi/openapi.yaml -p 8081
+internal/lint: docker-build ## lintチェックします
+	docker compose run -it redocly redocly lint internalapi/openapi.yaml
+external/lint: docker-build ## lintチェックします
+	docker compose run -it redocly redocly lint externalapi/openapi.yaml
 
-internal-lint: docker-up
-	${DOCKER_RUN} redocly lint internalapi/openapi.yaml
-external-lint: docker-up
-	${DOCKER_RUN} redocly lint externalapi/openapi.yaml
+internal/bundle: docker-build ## 1ファイルにバンドルします
+	docker compose run -it redocly redocly bundle internalapi/openapi.yaml --output=build/openapi-bundled-internal.yaml
+external/bundle: docker-build ## 1ファイルにバンドルします
+	docker compose run -it redocly redocly bundle externalapi/openapi.yaml --output=build/openapi-bundled-external.yaml
 
-internal-bundle: docker-up
-	${DOCKER_RUN} redocly bundle internalapi/openapi.yaml --output=internalapi/openapi-bundled.yaml
-external-bundle: docker-up
-	${DOCKER_RUN} redocly bundle externalapi/openapi.yaml --output=externalapi/openapi-bundled.yaml
+internal/build: docker-build ## 定義をhtmlのドキュメントで出力します
+	docker compose run -it redocly redocly build-docs internalapi/openapi.yaml --output=build/internal.html
+external/build: docker-build ## 定義をhtmlのドキュメントで出力します
+	docker compose run -it redocly redocly build-docs externalapi/openapi.yaml --output=build/external.html
 
-
-internal-build: docker-up
-	${DOCKER_RUN} redocly build-docs internalapi/openapi.yaml --output=build/internal.html
-external-build: docker-up
-	${DOCKER_RUN} redocly build-docs externalapi/openapi.yaml --output=build/external.html
-
-internal-serve:
-	${DOCKER_RUN} serve build/internal.html --host 0.0.0.0 -p 8090
-external-serve:
-	${DOCKER_RUN} serve build/external.html --host 0.0.0.0 -p 8091
-
-
-internal-mock: internal-bundle
-	${DOCKER_RUN} prism mock ./internalapi/openapi-bundled.yaml --host 0.0.0.0
-external-mock: external-bundle
-	${DOCKER_RUN} prism mock ./externalapi/openapi-bundled.yaml --host 0.0.0.0
-
-
-docker-up:
-	docker compose up -d redocly
+internal/mock: docker-build internal/bundle ## prismでモックサーバーを起動します
+	docker compose run -it -p 127.0.0.1:4010:4010 redocly prism mock ./internalapi/openapi-bundled.yaml --host 0.0.0.0
+external/mock: docker-build external/bundle ## prismでモックサーバーを起動します
+	docker compose run -it -p 127.0.0.1:4010:4010 redocly prism mock ./externalapi/openapi-bundled.yaml --host 0.0.0.0
 
 docker-build:
-	docker compose build redocly
-
-docker-down:
-	docker compose down --remove-orphans
+	docker compose build 
 
 
-help:
-	# > internal-preview
-	# > external-preview
-	# API定義確認サーバーを起動します
-	#
-	# > internal-lint
-	# > external-lint
-	# lintチェックします
-	#
-	# > internal-bundle
-	# > external-bundle
-	# 1ファイルにバンドルします
-	#
-	# > internal-build
-	# > external-build
-	# 定義をhtmlのドキュメントで出力します
-	#
-	# > internal-serve
-	# > external-serve
-	# buildしたファイルを確認します
-	#
-	# > internal-mock
-	# > external-mock
-	# prismでモックサーバーを起動します
+# https://ktrysmt.github.io/blog/write-useful-help-command-by-shell/
+help: ## print this message
+	@printf "\033[36m%-25s\033[0m %-50s %s\n" "[command]" "[Description]" 
+	@grep -E '^[/a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'

--- a/packages/shared/openapi/Makefile
+++ b/packages/shared/openapi/Makefile
@@ -8,19 +8,19 @@ external/preview: docker-build ## API定義確認サーバーを起動します
 	docker compose run -it -p 127.0.0.1:8081:8081 redocly redocly preview-docs --host 0.0.0.0 externalapi/openapi.yaml -p 8081
 
 internal/lint: docker-build ## lintチェックします
-	docker compose run -it redocly redocly lint internalapi/openapi.yaml
+	docker compose run redocly redocly lint internalapi/openapi.yaml
 external/lint: docker-build ## lintチェックします
-	docker compose run -it redocly redocly lint externalapi/openapi.yaml
+	docker compose run redocly redocly lint externalapi/openapi.yaml
 
 internal/bundle: docker-build ## 1ファイルにバンドルします
-	docker compose run -it redocly redocly bundle internalapi/openapi.yaml --output=build/openapi-bundled-internal.yaml
+	docker compose run redocly redocly bundle internalapi/openapi.yaml --output=build/openapi-bundled-internal.yaml
 external/bundle: docker-build ## 1ファイルにバンドルします
-	docker compose run -it redocly redocly bundle externalapi/openapi.yaml --output=build/openapi-bundled-external.yaml
+	docker compose run redocly redocly bundle externalapi/openapi.yaml --output=build/openapi-bundled-external.yaml
 
 internal/build: docker-build ## 定義をhtmlのドキュメントで出力します
-	docker compose run -it redocly redocly build-docs internalapi/openapi.yaml --output=build/internal.html
+	docker compose run redocly redocly build-docs internalapi/openapi.yaml --output=build/internal.html
 external/build: docker-build ## 定義をhtmlのドキュメントで出力します
-	docker compose run -it redocly redocly build-docs externalapi/openapi.yaml --output=build/external.html
+	docker compose run redocly redocly build-docs externalapi/openapi.yaml --output=build/external.html
 
 internal/mock: docker-build internal/bundle ## prismでモックサーバーを起動します
 	docker compose run -it -p 127.0.0.1:4010:4010 redocly prism mock ./internalapi/openapi-bundled.yaml --host 0.0.0.0

--- a/packages/shared/openapi/docker-compose.yaml
+++ b/packages/shared/openapi/docker-compose.yaml
@@ -19,3 +19,4 @@ services:
       - "127.0.0.1:4020:4010"
     working_dir: /openapi
     tty: true
+    init: true

--- a/packages/shared/openapi/docker-compose.yaml
+++ b/packages/shared/openapi/docker-compose.yaml
@@ -18,5 +18,4 @@ services:
       # prismは別のファイルとして分離したい
       - "127.0.0.1:4020:4010"
     working_dir: /openapi
-    tty: true
     init: true

--- a/packages/shared/openapi/docker/Dockerfile
+++ b/packages/shared/openapi/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:20.11.1-alpine
 
-RUN npm install --global @redocly/cli@1.10.5 @stoplight/prism-cli@5.6.0
+RUN npm install --global @redocly/cli@1.12.0 @stoplight/prism-cli@5.8.1
 
 EXPOSE 8080


### PR DESCRIPTION
# Issue
<!--
対応するissueを記載してください。
URLでも可ですが、issueのclose忘れ等を避けるためキーワードを利用した記載を推奨します。
https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
e.g.) Closes #10
-->

Closes #394 

# Overview
<!-- 対応背景、内容等を記載してください。 -->

OpenAPI起動の修正のほか、以下の調整を行いました。

- フロントエンドと同形式の make help に変更
- ほぼ利用しないserveコマンドを削除
- 生成物は全て build/ 配下に行くように統一。**bundle コマンドの実行結果も build 配下になるように変更したので注意してください**

build/openapi-bundled-internal.yaml
build/openapi-bundled-external.yaml

# Operation Verification
<!-- 動作検証結果のログ等があれば記載してください。 -->

```
$ make
[command]                 [Description]                                      
internal/preview          API定義確認サーバーを起動します
external/preview          API定義確認サーバーを起動します
internal/lint             lintチェックします
external/lint             lintチェックします
internal/bundle           1ファイルにバンドルします
external/bundle           1ファイルにバンドルします
internal/build            定義をhtmlのドキュメントで出力します
external/build            定義をhtmlのドキュメントで出力します
internal/mock             prismでモックサーバーを起動します
external/mock             prismでモックサーバーを起動します
help                      print this message
```

# Check List

- [x] セルフレビューをした(must)
- [ ] テストコードを記載した
- [ ] 動作検証の結果を記載した
- [x] 関連するドキュメントの更新をした
- [x] 適切なLabelを設定した(e.g. frontend, documentation)
- [x] 適切なProjectを設定した(e.g. Minimum Structure)

# Others
<!-- 補足等あれば記載してください。 -->
