### PR TITLE
Fix openapi hot reload

### DIFF
--- a/packages/shared/openapi/Makefile
+++ b/packages/shared/openapi/Makefile
@@ -2,10 +2,10 @@ DOCKER_RUN := docker compose run -it redocly
 
 .DEFAULT_GOAL := help
 
-internal/preview: docker-build ## API定義確認サーバーを起動します
-	docker compose run -it -p 127.0.0.1:8080:8080 redocly redocly preview-docs --host 0.0.0.0 internalapi/openapi.yaml -p 8080
-external/preview: docker-build ## API定義確認サーバーを起動します
-	docker compose run -it -p 127.0.0.1:8081:8081 redocly redocly preview-docs --host 0.0.0.0 externalapi/openapi.yaml -p 8081
+internal/preview: docker-build ## API定義確認サーバーを起動します(hot reload)
+	docker compose run -it -p 127.0.0.1:8080:8080 -p 127.0.0.1:32201:32201 redocly redocly preview-docs --host 0.0.0.0 internalapi/openapi.yaml -p 8080
+external/preview: docker-build ## API定義確認サーバーを起動します(hot reload)
+	docker compose run -it -p 127.0.0.1:8081:8081 -p 127.0.0.1:32201:32201 redocly redocly preview-docs --host 0.0.0.0 externalapi/openapi.yaml -p 8081
 
 internal/lint: docker-build ## lintチェックします
 	docker compose run redocly redocly lint internalapi/openapi.yaml


### PR DESCRIPTION
# Issue
<!--
対応するissueを記載してください。
URLでも可ですが、issueのclose忘れ等を避けるためキーワードを利用した記載を推奨します。
https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
e.g.) Closes #10
-->

# Overview
<!-- 対応背景、内容等を記載してください。 -->

redocly のホットリロードが効いていなかったので、該当ポートを開けるよう追記しました。

# Operation Verification
<!-- 動作検証結果のログ等があれば記載してください。 -->

元々こういうログが出ていました

![image](https://github.com/stlatica/stlatica/assets/18499975/51dca09c-a8dc-4248-9a05-9b63f60117b8)

これを解消しました

# Check List

- [x] セルフレビューをした(must)
- [ ] テストコードを記載した
- [ ] 動作検証の結果を記載した
- [x] 関連するドキュメントの更新をした
- [x] 適切なLabelを設定した(e.g. frontend, documentation)
- [ ] 適切なProjectを設定した(e.g. Minimum Structure)

# Others
<!-- 補足等あれば記載してください。 -->
