### PR TITLE
golangがインストールされていない環境でもmakeを使用できるように修正

### DIFF
--- a/packages/backend/Makefile
+++ b/packages/backend/Makefile
@@ -45,7 +45,7 @@ local/start-internalapi: set-go-env ## start internalapi on local
 docker/start-internalapi: ## start internalapi on docker
 	SOURCE_DIR=./app/cmd/internalapi docker compose up -d stlatica_server
 
-docker/stop-internalapi: set-go-env ## stop internalapi on docker
+docker/stop-internalapi: ## stop internalapi on docker
 	SOURCE_DIR=./app/cmd/internalapi docker compose down stlatica_server
 
 docker/start-object-storage: ## start object storage on docker

--- a/packages/backend/Makefile
+++ b/packages/backend/Makefile
@@ -1,29 +1,34 @@
-export GOBIN := $(PWD)/bin
-GO_PATH:=$(shell go env GOPATH)
-export PATH:=$(GOBIN):$(GO_PATH):$(PATH)
+.DEFAULT_GOAL := help
 
-list:
-	@grep "^[a-zA-Z\-]*:" Makefile | grep -v "grep" | sed -e 's/^/make /' | sed -e 's/://'
+set-go-env:
+	$(eval GOBIN=$(PWD)/bin)
+	$(eval PATH=$(GOBIN):$(shell go env GOPATH):$(PATH))
 
-install-tools:
+local/install-tools: set-go-env ## install tools on local
 	@./tools/install_tools.sh "./tools/tools.go"
 
-start-local-db:
+docker/start-db: ## start db on docker
 	docker compose up -d stlatica_db
 
-create-migration-file:
+local/create-migration-file: set-go-env ## create migration file on local
 	$(GOBIN)/goose -dir=db/migrations create new_migration sql
 
-migration-up:
-	$(GOBIN)/goose -dir=./db/migrations mysql "root@tcp(localhost:4000)/stlatica" up
+local/migration-up: set-go-env ## run migration on local
+	$(GOBIN)/goose -dir=./db/migrations mysql "root@tcp(localhost:4000)/stlatica" up;
 
-migration-down:
+docker/migration-up: ## run migration on docker
+	docker compose run --rm goose bash -c "`goose -dir=./db/migrations mysql "root@tcp(127.0.0.1:4000)/stlatica" up`"
+
+local/migration-down: set-go-env ## run migration down on local
 	$(GOBIN)/goose -dir=./db/migrations mysql "root@tcp(localhost:4000)/stlatica" down	
 
-generate-code-from-db:
+docker/migration-down: ## run migration down on docker
+	docker compose run --rm goose bash -c "`goose -dir=./db/migrations mysql "root@tcp(127.0.0.1:4000)/stlatica" down`"
+
+local/generate-code-from-db: set-go-env ## generate code from db on local
 	@./db/sqlboiler/generate_codes.sh
 
-codegen-from-oapi:
+local/codegen-from-oapi: set-go-env ## generate code from openapi on local
 	mkdir ../shared/openapi/tmp
 	docker compose up redocly
 	$(GOBIN)/oapi-codegen -generate server -package openapi ../shared/openapi/tmp/internalapi/openapi.yaml > app/controllers/internalapi/v1/openapi/internalapi_server.gen.go
@@ -31,26 +36,27 @@ codegen-from-oapi:
 	$(GOBIN)/oapi-codegen -generate spec -package openapi ../shared/openapi/tmp/internalapi/openapi.yaml > app/controllers/internalapi/v1/openapi/internalapi_spec.gen.go
 	rm -r ../shared/openapi/tmp
 
-lint:
+local/lint: set-go-env ## lint on local
 	$(GOBIN)/golangci-lint run ./...
 
-start-local-internalapi:
+local/start-internalapi: set-go-env ## start internalapi on local
 	GO_ENV=local go run app/cmd/internalapi/main.go
 
-start-docker-internalapi:
+docker/start-internalapi: ## start internalapi on docker
 	SOURCE_DIR=./app/cmd/internalapi docker compose up -d stlatica_server
 
-stop-docker-internalapi:
+docker/stop-internalapi: set-go-env ## stop internalapi on docker
 	SOURCE_DIR=./app/cmd/internalapi docker compose down stlatica_server
 
-
-start-object-storage:
+docker/start-object-storage: ## start object storage on docker
 	docker compose up -d minio
 
-stop-object-storage:
+docker/stop-object-storage: ## stop object storage on docker
 	docker compose down minio
 
-# モックサーバーの起動
-start-mock-internalapi:
+docker/start-mock-internalapi: ## start mock internalapi on docker
 	docker run --rm -p 127.0.0.1:8080:8080 --mount type=bind,source="./",target="/go/src" -w /go/src -it golang:1.20.6 /bin/sh -c "go run mock/cmd/internalapi/main.go"
 
+help: ## print this message ## make
+	@printf "\033[36m%-30s\033[0m %-50s %s\n" "[command]" "[Description]"
+	@grep -E '^[/a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/packages/backend/Makefile
+++ b/packages/backend/Makefile
@@ -17,13 +17,13 @@ local/migration-up: set-go-env ## run migration on local
 	$(GOBIN)/goose -dir=./db/migrations mysql "root@tcp(localhost:4000)/stlatica" up;
 
 docker/migration-up: ## run migration on docker
-	docker compose run --rm goose bash -c "`goose -dir=./db/migrations mysql "root@tcp(127.0.0.1:4000)/stlatica" up`"
+	docker compose run --rm goose bash -c "goose -dir=./db/migrations mysql 'root@tcp(stlatica_db)/stlatica' up"
 
 local/migration-down: set-go-env ## run migration down on local
-	$(GOBIN)/goose -dir=./db/migrations mysql "root@tcp(localhost:4000)/stlatica" down	
+	$(GOBIN)/goose -dir=./db/migrations mysql "root@tcp(localhost:4000)/stlatica" down
 
 docker/migration-down: ## run migration down on docker
-	docker compose run --rm goose bash -c "`goose -dir=./db/migrations mysql "root@tcp(127.0.0.1:4000)/stlatica" down`"
+	docker compose run --rm goose bash -c "goose -dir=./db/migrations mysql 'root@tcp(stlatica_db)/stlatica' down"
 
 local/generate-code-from-db: set-go-env ## generate code from db on local
 	@./db/sqlboiler/generate_codes.sh

--- a/packages/backend/docker-compose.yaml
+++ b/packages/backend/docker-compose.yaml
@@ -2,6 +2,7 @@ version: "3.9"
 
 services:
   stlatica_db:
+    container_name: stlatica_db
     image: mysql:8.0.34
     env_file:
       ./.env.local.docker

--- a/packages/backend/docker-compose.yaml
+++ b/packages/backend/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - "8080:8080"
     volumes:
       - ./:/app
-    command: sh -c 'air -c .air.toml --build.cmd "go build -o ./tmp/main $SOURCE_DIR"'
+    command: sh -c 'air -c .air.toml --build.cmd "go build -o ./tmp/main ${SOURCE_DIR:-./app/cmd/internalapi}"'
   redocly:
     build:
       context: .
@@ -39,3 +39,9 @@ services:
       - "9001:9001"
     volumes:
       - ./data/minio:/data
+  goose:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile_goose
+    volumes:
+      - ./:/app

--- a/packages/backend/docker-compose.yaml
+++ b/packages/backend/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - GO_ENV=local.docker
     build:
       context: .
-      dockerfile: Docker/Dockerfile_air
+      dockerfile: ./docker/Dockerfile_air
     ports:
       - "8080:8080"
     volumes:

--- a/packages/backend/docker/Dockerfile_air
+++ b/packages/backend/docker/Dockerfile_air
@@ -2,7 +2,7 @@ FROM golang:1.20.6
 
 WORKDIR /app
 
-RUN go install github.com/cosmtrek/air@latest
+RUN go install github.com/air-verse/air@latest
 COPY go.mod go.sum ./
 COPY .env.local.docker ./
 RUN go mod download

--- a/packages/backend/docker/Dockerfile_goose
+++ b/packages/backend/docker/Dockerfile_goose
@@ -1,0 +1,5 @@
+FROM golang:1.20.6
+
+WORKDIR /app
+
+RUN go install github.com/pressly/goose/v3/cmd/goose@latest


### PR DESCRIPTION
# Issue
<!--
対応するissueを記載してください。
URLでも可ですが、issueのclose忘れ等を避けるためキーワードを利用した記載を推奨します。
https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
e.g.) Closes #10
-->

none

# Overview
<!-- 対応背景、内容等を記載してください。 -->

backend packageのMakefileはgolangがインストールされている前提で記述されていたため、golangがインストールされていない環境では動作しない状態となっていました。
本PRではこれを修正し、golangがインストールされていない状態でも一部のmake targetを実行できるようにします。

# Operation Verification
<!-- 動作検証結果のログ等があれば記載してください。 -->

frontend側での動作検証に必要なdb立ち上げ、migration、serverの実行がdocker環境のみで実行されることを確認しました。

# Check List

- [x] セルフレビューをした(must)
- [ ] テストコードを記載した
- [x] 動作検証の結果を記載した
- [ ] 関連するドキュメントの更新をした
- [x] 適切なLabelを設定した(e.g. frontend, documentation)
<!-- - [ ] 適切なProjectを設定した(e.g. Minimum Structure) -->

# Others
<!-- 補足等あれば記載してください。 -->
