### PR TITLE
error handlingを修正

### DIFF
--- a/packages/backend/app/adapters/images/adapter.go
+++ b/packages/backend/app/adapters/images/adapter.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 
+	domainerrors "github.com/stlatica/stlatica/packages/backend/app/domains/errors"
 	"github.com/stlatica/stlatica/packages/backend/app/domains/types"
 	"github.com/stlatica/stlatica/packages/backend/app/pkg/objectstorage"
 	"github.com/stlatica/stlatica/packages/backend/app/usecases/images/ports"
@@ -63,6 +64,7 @@ func validateMineType(data []byte) (string, error) {
 	case mine == GifMineType:
 		return mine, nil
 	default:
-		return "", fmt.Errorf("invalid file type, mine type: %s", mine)
+		return "", domainerrors.NewDomainError(fmt.Errorf("invalid file type, mine type: %s", mine),
+			domainerrors.DomainErrorTypeInvalidData, "invalid file type")
 	}
 }

--- a/packages/backend/app/controllers/internalapi/v1/error_handler.go
+++ b/packages/backend/app/controllers/internalapi/v1/error_handler.go
@@ -1,26 +1,60 @@
 package v1
 
 import (
+	"fmt"
 	"net/http"
+	"time"
 
+	"github.com/friendsofgo/errors"
 	"github.com/labstack/echo/v4"
+	"github.com/stlatica/stlatica/packages/backend/app/controllers/internalapi/v1/openapi"
+	domainerrors "github.com/stlatica/stlatica/packages/backend/app/domains/errors"
 	"github.com/stlatica/stlatica/packages/backend/app/pkg/logger"
 )
 
-type tmpErrorMessage struct {
-	Message string `json:"message"`
+type errorResponse struct {
+	Code    openapi.ErrorResponseCode `json:"code"`
+	Message string                    `json:"message"`
 }
 
 // NewErrorHandler returns a new HTTPErrorHandler.
-func NewErrorHandler(_ *echo.Echo, _ *logger.AppLogger) echo.HTTPErrorHandler {
+func NewErrorHandler(_ *echo.Echo, appLogger *logger.AppLogger) echo.HTTPErrorHandler {
 	return func(err error, ectx echo.Context) {
-		// TODO: 実際のエラーハンドリング処理を実装する https://github.com/stlatica/stlatica/issues/590
-		_ = ectx.JSON(http.StatusInternalServerError,
-			tmpErrorMessage{
-				Message: err.Error(),
-			})
+		var responseStatusCode int
+		var responseErrorCode openapi.ErrorResponseCode
+		var responseMessage string
+
+		var domainError domainerrors.DomainError
+		if errors.As(err, &domainError) {
+			switch domainError.DomainErrorType() {
+			case domainerrors.DomainErrorTypeNotFound:
+				responseStatusCode = http.StatusNotFound
+				responseErrorCode = openapi.NOTFOUND
+			case domainerrors.DomainErrorTypeInvalidData:
+				responseStatusCode = http.StatusBadRequest
+				responseErrorCode = openapi.BADREQUEST
+			default:
+				responseStatusCode = http.StatusInternalServerError
+				responseErrorCode = openapi.INTERNALSERVERERROR
+			}
+			responseMessage = domainError.Error()
+		} else {
+			responseStatusCode = http.StatusInternalServerError
+			responseErrorCode = openapi.INTERNALSERVERERROR
+			responseMessage = err.Error()
+		}
 		// TODO: trace IDとuser IDをcontextから取得してログに出力する https://github.com/stlatica/stlatica/issues/403
-		// appLogger.Error(ectx.Request().Context(), err.Error(), "", time.Now(), "")
-		// e.DefaultHTTPErrorHandler(err, ectx)
+		appLogger.Error(ectx.Request().Context(), err.Error(), "", time.Now(), "")
+
+		err = ectx.JSON(responseStatusCode,
+			errorResponse{
+				Code:    responseErrorCode,
+				Message: responseMessage,
+			})
+		if err != nil {
+			// TODO: trace IDとuser IDをcontextから取得してログに出力する https://github.com/stlatica/stlatica/issues/403
+			appLogger.Error(ectx.Request().Context(),
+				fmt.Sprintf("failed to send error response: %s", err.Error()), "", time.Now(), "")
+		}
 	}
 }

--- a/packages/backend/app/domains/errors/domain_error.go
+++ b/packages/backend/app/domains/errors/domain_error.go
@@ -1,0 +1,33 @@
+package errors
+
+import "fmt"
+
+// DomainError is an interface for domain error
+type DomainError interface {
+	error
+	// DomainErrorType returns the type of domain error
+	DomainErrorType() DomainErrorType
+}
+
+type domainError struct {
+	orgError  error
+	errorType DomainErrorType
+	message   string
+}
+
+// NewDomainError returns a new DomainError
+func NewDomainError(orgError error, errorType DomainErrorType, msg string) DomainError {
+	return domainError{
+		errorType: errorType,
+		orgError:  orgError,
+		message:   msg,
+	}
+}
+
+func (d domainError) DomainErrorType() DomainErrorType {
+	return d.errorType
+}
+
+func (d domainError) Error() string {
+	return fmt.Sprintf("%s: %s", d.message, d.orgError.Error())
+}

--- a/packages/backend/app/domains/errors/error_type.go
+++ b/packages/backend/app/domains/errors/error_type.go
@@ -1,0 +1,12 @@
+package errors
+
+// DomainErrorType is a type for domain error type
+type DomainErrorType int
+
+const (
+	_ DomainErrorType = iota
+	// DomainErrorTypeNotFound is a domain error type for not found error
+	DomainErrorTypeNotFound
+	// DomainErrorTypeInvalidData is a domain error type for invalid data error
+	DomainErrorTypeInvalidData
+)

--- a/packages/backend/app/repositories/dao/plat_dao.go
+++ b/packages/backend/app/repositories/dao/plat_dao.go
@@ -2,8 +2,11 @@ package dao
 
 import (
 	"context"
+	"database/sql"
 
+	"github.com/friendsofgo/errors"
 	domainentities "github.com/stlatica/stlatica/packages/backend/app/domains/entities"
+	domainerrors "github.com/stlatica/stlatica/packages/backend/app/domains/errors"
 	domainports "github.com/stlatica/stlatica/packages/backend/app/domains/plats/ports"
 	"github.com/stlatica/stlatica/packages/backend/app/domains/types"
 	"github.com/stlatica/stlatica/packages/backend/app/repositories/entities"
@@ -36,6 +39,10 @@ type platDAO struct {
 func (dao *platDAO) GetPlat(ctx context.Context, platID types.PlatID) (*domainentities.Plat, error) {
 	entity, err := entities.FindPlatBase(ctx, dao.ctxExecutor, platID)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, domainerrors.NewDomainError(err,
+				domainerrors.DomainErrorTypeNotFound, "user not found")
+		}
 		return nil, err
 	}
 

--- a/packages/backend/app/repositories/dao/user_dao.go
+++ b/packages/backend/app/repositories/dao/user_dao.go
@@ -2,9 +2,12 @@ package dao
 
 import (
 	"context"
+	"database/sql"
 	"reflect"
 
+	"github.com/friendsofgo/errors"
 	domainentities "github.com/stlatica/stlatica/packages/backend/app/domains/entities"
+	domainerrors "github.com/stlatica/stlatica/packages/backend/app/domains/errors"
 	"github.com/stlatica/stlatica/packages/backend/app/domains/types"
 	domainports "github.com/stlatica/stlatica/packages/backend/app/domains/users/ports"
 	"github.com/stlatica/stlatica/packages/backend/app/repositories/entities"
@@ -39,6 +42,10 @@ type userDAO struct {
 func (dao *userDAO) GetUser(ctx context.Context, userID types.UserID) (*domainentities.User, error) {
 	entity, err := entities.FindUserBase(ctx, dao.ctxExecutor, userID)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, domainerrors.NewDomainError(err,
+				domainerrors.DomainErrorTypeNotFound, "user not found")
+		}
 		return nil, err
 	}
 
@@ -50,6 +57,10 @@ func (dao *userDAO) GetUserByPreferredUserID(ctx context.Context,
 	query := entities.UserBaseWhere.PreferredUserID.EQ(preferredUserID)
 	entity, err := entities.Users(query).One(ctx, dao.ctxExecutor)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, domainerrors.NewDomainError(err,
+				domainerrors.DomainErrorTypeNotFound, "user not found")
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
# Issue
<!--
対応するissueを記載してください。
URLでも可ですが、issueのclose忘れ等を避けるためキーワードを利用した記載を推奨します。
https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
e.g.) Closes #10
-->

Closes #590 

# Overview
<!-- 対応背景、内容等を記載してください。 -->

`app/controllers/internalapi/v1/error_handler.go`において適切なerror responseを返すようにしました。

domain layerにdomain errorを追加し、この値を元にerror_handler.goで適切なstatus codeへ振り分ける処理を行っています。
domain errorは単純に各status codeに分類されるerrorではなく、domain logicに基づいたerrorです。
e.g.) invalid data, connection error

domain error typeではgoでよく取り入れられてるiotaを用いた方法でenumを表現しています。（`fmt.Stringer`インターフェースは必要になったら別途実装します）

# Operation Verification
<!-- 動作検証結果のログ等があれば記載してください。 -->

本PRでは、主要なerrorのうち一部のhandlingを修正しました。

`GET /internal/v1/users/{user_id}`でユーザが見つからないケース

```shell
% curl -i "http://localhost:8080/internal/v1/users/hoge"
HTTP/1.1 404 Not Found
Content-Type: application/json
Vary: Origin
Date: Sun, 01 Sep 2024 13:52:23 GMT
Content-Length: 76

{"code":"NOT_FOUND","message":"user not found: sql: no rows in result set"}
```

base64ではないデータを`POST /internal/v1/images`に渡したケース

```shell
% curl -i -X POST 'http://localhost:8080/internal/v1/images' -d 'hoge'
HTTP/1.1 400 Bad Request
Content-Type: application/json
Vary: Origin
Date: Sun, 01 Sep 2024 13:54:18 GMT
Content-Length: 109

{"code":"BAD_REQUEST","message":"invalid file type: invalid file type, mine type: application/octet-stream"}
```

# Check List

- [x] セルフレビューをした(must)
- [ ] テストコードを記載した
- [x] 動作検証の結果を記載した
- [ ] 関連するドキュメントの更新をした
- [x] 適切なLabelを設定した(e.g. frontend, documentation)
<!-- - [ ] 適切なProjectを設定した(e.g. Minimum Structure) -->

# Others
<!-- 補足等あれば記載してください。 -->
