### PR TITLE
go air のバージョンをlatestではなく直接指定

### DIFF
--- a/packages/backend/docker/Dockerfile_air
+++ b/packages/backend/docker/Dockerfile_air
@@ -2,7 +2,7 @@ FROM golang:1.22.6
 
 WORKDIR /app
 
-RUN go install github.com/air-verse/air@latest
+RUN go install github.com/air-verse/air@v1.52.3
 COPY go.mod go.sum ./
 COPY .env.local.docker ./
 RUN go mod download


### PR DESCRIPTION
# Issue
<!--
対応するissueを記載してください。
URLでも可ですが、issueのclose忘れ等を避けるためキーワードを利用した記載を推奨します。
https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
e.g.) Closes #10
-->

# Overview
<!-- 対応背景、内容等を記載してください。 -->

air パッケージの更新により latest で取得するバージョンの要求Goバージョンが1.23になっており、エラーでバックエンドのビルドができなくなっていました。

latest ではなくきちんと指定するようにしました。

https://github.com/air-verse/air/releases/tag/v1.60.0

# Operation Verification
<!-- 動作検証結果のログ等があれば記載してください。 -->

```make docker/start-internalapi``` でエラーが起きなくなったことを確認

# Check List

- [ ] セルフレビューをした(must)
- [ ] テストコードを記載した
- [x] 動作検証の結果を記載した
- [ ] 関連するドキュメントの更新をした
- [ ] 適切なLabelを設定した(e.g. frontend, documentation)
<!-- - [ ] 適切なProjectを設定した(e.g. Minimum Structure) -->

# Others
<!-- 補足等あれば記載してください。 -->

ここ以外も全て latest 指定はやめておいたほうがいいと思います！