### PR TITLE
valkeyを起動するための設定を追加

### DIFF
--- a/packages/backend/Makefile
+++ b/packages/backend/Makefile
@@ -55,6 +55,12 @@ docker/start-object-storage: ## start object storage on docker
 docker/stop-object-storage: ## stop object storage on docker
 	docker compose down minio
 
+docker/start-valkey: ## start valkey server on docker
+	docker compose up -d valkey
+
+docker/stop-valkey: ## stop valkey server on docker
+	docker compose down valkey
+
 docker/start-mock-internalapi: ## start mock internalapi on docker
 	docker run --rm -p 127.0.0.1:8080:8080 --mount type=bind,source="./",target="/go/src" -w /go/src -it golang:1.20.6 /bin/sh -c "go run mock/cmd/internalapi/main.go"
 

--- a/packages/backend/docker-compose.yaml
+++ b/packages/backend/docker-compose.yaml
@@ -29,6 +29,13 @@ services:
       - ../shared/openapi/externalapi:/openapi/externalapi
       - ../shared/openapi/internalapi:/openapi/internalapi
       - ../shared/openapi/tmp:/openapi/tmp
+  valkey:
+    image: valkey/valkey:latest
+    command: valkey-server --port 6380
+    ports:
+      - "6380:6380"
+    volumes:
+      - ./data/valkey:/data
   minio:
     build:
       context: .


### PR DESCRIPTION
# Issue
<!--
対応するissueを記載してください。
URLでも可ですが、issueのclose忘れ等を避けるためキーワードを利用した記載を推奨します。
https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
e.g.) Closes #10
-->

Closes #337 

# Overview
<!-- 対応背景、内容等を記載してください。 -->

認証周りの処理で使用するvalkeyを起動するための設定を追加します。

# Operation Verification
<!-- 動作検証結果のログ等があれば記載してください。 -->

containerが正常に起動することを確認しました。

起動ログ
```
~/src/.../packages/backend  % make docker/start-valkey 
docker compose up -d valkey
[+] Running 8/8
 ✔ valkey Pulled                                                                                                                                                                                       8.2s 
   ✔ 14c9d9d19932 Pull complete                                                                                                                                                                        3.8s 
   ✔ eee1e0a39046 Pull complete                                                                                                                                                                        3.8s 
   ✔ 5001f8159f3f Pull complete                                                                                                                                                                        3.8s 
   ✔ e86561109818 Pull complete                                                                                                                                                                        4.7s 
   ✔ 6b444d87f421 Pull complete                                                                                                                                                                        4.7s 
   ✔ 4f4fb700ef54 Pull complete                                                                                                                                                                        4.7s 
   ✔ 1b215b3aac50 Pull complete                                                                                                                                                                        4.7s 
[+] Running 1/1
 ✔ Container backend-valkey-1  Started 
```

container内ログ
```
1:C 12 Oct 2024 14:26:20.942 * oO0OoO0OoO0Oo Valkey is starting oO0OoO0OoO0Oo
1:C 12 Oct 2024 14:26:20.942 * Valkey version=8.0.1, bits=64, commit=00000000, modified=0, pid=1, just started
1:C 12 Oct 2024 14:26:20.942 * Configuration loaded
1:M 12 Oct 2024 14:26:20.943 * monotonic clock: POSIX clock_gettime
1:M 12 Oct 2024 14:26:20.943 * Running mode=standalone, port=6380.
1:M 12 Oct 2024 14:26:20.944 * Server initialized
1:M 12 Oct 2024 14:26:20.944 * Ready to accept connections tcp
```

# Check List

- [x] セルフレビューをした(must)
- [ ] テストコードを記載した
- [x] 動作検証の結果を記載した
- [ ] 関連するドキュメントの更新をした
- [ ] 適切なLabelを設定した(e.g. frontend, documentation)
<!-- - [ ] 適切なProjectを設定した(e.g. Minimum Structure) -->

# Others
<!-- 補足等あれば記載してください。 -->
