### PR TITLE
コマンドの名称をobject-storageからminioに変更

### DIFF
--- a/packages/backend/Makefile
+++ b/packages/backend/Makefile
@@ -49,10 +49,10 @@ docker/start-internalapi: ## start internalapi on docker
 docker/stop-internalapi: ## stop internalapi on docker
 	SOURCE_DIR=./app/cmd/internalapi docker compose down stlatica_server
 
-docker/start-object-storage: ## start object storage on docker
+docker/start-minio: ## start object storage on docker
 	docker compose up -d minio
 
-docker/stop-object-storage: ## stop object storage on docker
+docker/stop-minio: ## stop object storage on docker
 	docker compose down minio
 
 docker/start-valkey: ## start valkey server on docker


### PR DESCRIPTION
# Issue
Closes #673
<!--
対応するissueを記載してください。
URLでも可ですが、issueのclose忘れ等を避けるためキーワードを利用した記載を推奨します。
https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
e.g.) Closes #10
-->

# Overview
<!-- 対応背景、内容等を記載してください。 -->
``make docker/start-object-storage`` を ``make docker/start-minio`` に変更しました。
また、``make docker/stop-object-storage`` も ``make docker/stop-minio`` に変更しました。

# Operation Verification
<!-- 動作検証結果のログ等があれば記載してください。 -->
- startのログ
```
$ make docker/start-minio 
docker compose up -d minio
WARN[0000] /home/polyester/code/stlatica/packages/backend/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Running 1/1
 ✔ Container backend-minio-1  Started                      
```

- stopのログ
```
$ make docker/stop-minio 
docker compose down minio
WARN[0000] /home/polyester/code/stlatica/packages/backend/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Running 2/2
 ✔ Container backend-minio-1  Removed                                                                                                                                                                         0.8s 
 ✔ Network backend_default    Removed                     
```


# Check List

- [x] セルフレビューをした(must)
- [ ] テストコードを記載した
- [x] 動作検証の結果を記載した
- [ ] 関連するドキュメントの更新をした
- [x] 適切なLabelを設定した(e.g. frontend, documentation)
<!-- - [ ] 適切なProjectを設定した(e.g. Minimum Structure) -->

# Others
<!-- 補足等あれば記載してください。 -->
