### PR TITLE
fix(frontend): reorder imports in Providers to satisfy Biome lint

### DIFF
--- a/packages/frontend/src/Providers.tsx
+++ b/packages/frontend/src/Providers.tsx
@@ -1,5 +1,5 @@
-import axios from "axios";
 import { MantineProvider } from "@mantine/core";
+import axios from "axios";
 import { SWRConfig } from "swr";
 
 import type { OnlyChildren } from "./utilities/utilities";


### PR DESCRIPTION
### Motivation
- CI frontend lint (`biome` organizeImports) failed due to import ordering in the Providers component, so imports were adjusted to make lint pass.

### Description
- Reordered imports in `packages/frontend/src/Providers.tsx` by placing `@mantine/core` before `axios` to conform to Biome's `organizeImports` rule.

### Testing
- Ran `cd packages/frontend && pnpm lint:ci` and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd0378920832fafb7ae21b47d3e9e)