### PR TITLE
Fix build_backend and lint_openapi CI stability

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -168,7 +168,7 @@ jobs:
       # setup go install
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.20.6"
+          go-version-file: packages/backend/go.mod
           cache: false
       # format
       - name: Run gofmt

--- a/packages/shared/openapi/Makefile
+++ b/packages/shared/openapi/Makefile
@@ -18,13 +18,17 @@ external/lint: ## lintチェックします
 	${DOCKER_RUN} redocly-cli redocly lint externalapi/openapi.yaml
 
 internal/bundle: ## 1ファイルにバンドルします
+	mkdir -p build
 	${DOCKER_RUN} redocly-cli redocly bundle internalapi/openapi.yaml --output=build/openapi-bundled-internal.yaml
 external/bundle: ## 1ファイルにバンドルします
+	mkdir -p build
 	${DOCKER_RUN} redocly-cli redocly bundle externalapi/openapi.yaml --output=build/openapi-bundled-external.yaml
 
 internal/build: ## 定義をhtmlのドキュメントで出力します
+	mkdir -p build
 	${DOCKER_RUN} redocly-cli redocly build-docs internalapi/openapi.yaml --output=build/internal.html
 external/build: ## 定義をhtmlのドキュメントで出力します
+	mkdir -p build
 	${DOCKER_RUN} redocly-cli redocly build-docs externalapi/openapi.yaml --output=build/external.html
 
 internal/mock: internal/bundle ## prismでモックサーバーを起動します


### PR DESCRIPTION
### Motivation
- The backend CI was pinned to a fixed Go version (`1.20.6`) while `packages/backend/go.mod` declares a different Go version, causing CI failures; OpenAPI bundle/build targets also failed when the `build/` directory did not exist in a clean CI workspace.

### Description
- Change `build_backend` workflow to use `go-version-file: packages/backend/go.mod` so the runner picks the Go version declared by the backend module (`.github/workflows/actions.yml`).
- Ensure OpenAPI `bundle`/`build` targets create the output directory by adding `mkdir -p build` before writing files (`packages/shared/openapi/Makefile`).

### Testing
- Ran `git diff --check` which returned no issues and succeeded.
- Ran `make help` in `packages/shared/openapi` which succeeded and displayed targets.
- Attempted `make external/lint` which failed in this environment due to missing Docker (`make: docker: No such file or directory`).
- Attempted `npx @redocly/cli` directly which failed due to npm registry access (403), so linting could not be fully executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e15c2b6038832f87ea7ff837cac278)